### PR TITLE
fix duplicate task docs

### DIFF
--- a/sphinxcontrib/prefecttask/__init__.py
+++ b/sphinxcontrib/prefecttask/__init__.py
@@ -15,7 +15,7 @@ if False:
     from typing import Any, Dict  # noqa
     from sphinx.application import Sphinx  # noqa
 
-__version__ = "0.1"
+__version__ = "0.2"
 
 def setup(app):
     """Setup Sphinx extension."""

--- a/sphinxcontrib/prefecttask/prefecttask.py
+++ b/sphinxcontrib/prefecttask/prefecttask.py
@@ -12,8 +12,7 @@ class TaskDocumenter(FunctionDocumenter):
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
-        return isinstance(member, Task)
-
+        return isinstance(member, Task) and member.name == membername
 
 class TaskDirective(PyFunction):
     """Sphinx task directive."""


### PR DESCRIPTION
This prevents duplicated task docs from being created when a task is set
as a variable and used as input to another.